### PR TITLE
Split dovecot config into multiple files

### DIFF
--- a/etc/dovecot-conf-d/10-auth.conf
+++ b/etc/dovecot-conf-d/10-auth.conf
@@ -2,127 +2,12 @@
 ## Authentication processes
 ##
 
-# Disable LOGIN command and all other plaintext authentications unless
-# SSL/TLS is used (LOGINDISABLED capability). Note that if the remote IP
-# matches the local IP (ie. you're connecting from the same computer), the
-# connection is considered secure and plaintext authentication is allowed.
-# See also ssl=required setting.
-#disable_plaintext_auth = yes
+disable_plaintext_auth = yes
 
-# Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
-# bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.
-#auth_cache_size = 0
-# Time to live for cached data. After TTL expires the cached record is no
-# longer used, *except* if the main database lookup returns internal failure.
-# We also try to handle password changes automatically: If user's previous
-# authentication was successful, but this one wasn't, the cache isn't used.
-# For now this works only with plaintext authentication.
-#auth_cache_ttl = 1 hour
-# TTL for negative hits (user not found, password mismatch).
-# 0 disables caching them completely.
-#auth_cache_negative_ttl = 1 hour
-
-# Space separated list of realms for SASL authentication mechanisms that need
-# them. You can leave it empty if you don't want to support multiple realms.
-# Many clients simply use the first one listed here, so keep the default realm
-# first.
-#auth_realms =
-
-# Default realm/domain to use if none was specified. This is used for both
-# SASL realms and appending @domain to username in plaintext logins.
-#auth_default_realm = 
-
-# List of allowed characters in username. If the user-given username contains
-# a character not listed in here, the login automatically fails. This is just
-# an extra check to make sure user can't exploit any potential quote escaping
-# vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
-# set this value to empty.
-#auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
-
-# Username character translations before it's looked up from databases. The
-# value contains series of from -> to characters. For example "#@/@" means
-# that '#' and '/' characters are translated to '@'.
-#auth_username_translation =
-
-# Username formatting before it's looked up from databases. You can use
-# the standard variables here, eg. %Lu would lowercase the username, %n would
-# drop away the domain if it was given, or "%n-AT-%d" would change the '@' into
-# "-AT-". This translation is done after auth_username_translation changes.
-#auth_username_format = %Lu
-
-# If you want to allow master users to log in by specifying the master
-# username within the normal username string (ie. not using SASL mechanism's
-# support for it), you can specify the separator character here. The format
-# is then <username><separator><master username>. UW-IMAP uses "*" as the
-# separator, so that could be a good choice.
-#auth_master_user_separator =
-
-# Username to use for users logging in with ANONYMOUS SASL mechanism
-#auth_anonymous_username = anonymous
-
-# Maximum number of dovecot-auth worker processes. They're used to execute
-# blocking passdb and userdb queries (eg. MySQL and PAM). They're
-# automatically created and destroyed as needed.
-#auth_worker_max_count = 30
-
-# Host name to use in GSSAPI principal names. The default is to use the
-# name returned by gethostname(). Use "$ALL" (with quotes) to allow all keytab
-# entries.
-#auth_gssapi_hostname =
-
-# Kerberos keytab to use for the GSSAPI mechanism. Will use the system
-# default (usually /etc/krb5.keytab) if not specified. You may need to change
-# the auth service to run as root to be able to read this file.
-#auth_krb5_keytab = 
-
-# Do NTLM and GSS-SPNEGO authentication using Samba's winbind daemon and
-# ntlm_auth helper. <doc/wiki/Authentication/Mechanisms/Winbind.txt>
-#auth_use_winbind = no
-
-# Path for Samba's ntlm_auth helper binary.
-#auth_winbind_helper_path = /usr/bin/ntlm_auth
-
-# Time to delay before replying to failed authentications.
-#auth_failure_delay = 2 secs
-
-# Require a valid SSL client certificate or the authentication fails.
-#auth_ssl_require_client_cert = no
-
-# Take the username from client's SSL certificate, using 
-# X509_NAME_get_text_by_NID() which returns the subject's DN's
-# CommonName. 
-#auth_ssl_username_from_cert = no
-
-# Space separated list of wanted authentication mechanisms:
-#   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp skey
-#   gss-spnego
-# NOTE: See also disable_plaintext_auth setting.
-auth_mechanisms = plain login digest-md5 cram-md5 
+auth_mechanisms = plain login 
 
 ##
 ## Password and user databases
 ##
 
-#
-# Password database is used to verify user's password (and nothing more).
-# You can have multiple passdbs and userdbs. This is useful if you want to
-# allow both system users (/etc/passwd) and virtual users to login without
-# duplicating the system users into virtual database.
-#
-# <doc/wiki/PasswordDatabase.txt>
-#
-# User database specifies where mails are located and what user/group IDs
-# own them. For single-UID configuration use "static" userdb.
-#
-# <doc/wiki/UserDatabase.txt>
-
-#!include auth-deny.conf.ext
-#!include auth-master.conf.ext
-
-#!include auth-system.conf.ext
 !include auth-sql.conf.ext
-#!include auth-ldap.conf.ext
-#!include auth-passwdfile.conf.ext
-#!include auth-checkpassword.conf.ext
-#!include auth-vpopmail.conf.ext
-#!include auth-static.conf.ext

--- a/etc/dovecot-conf-d/10-director.conf
+++ b/etc/dovecot-conf-d/10-director.conf
@@ -1,0 +1,6 @@
+##
+## Director-specific settings.
+##
+
+service director {
+}

--- a/etc/dovecot-conf-d/10-mail.conf
+++ b/etc/dovecot-conf-d/10-mail.conf
@@ -1,0 +1,21 @@
+##
+## Mailbox locations and namespaces
+##
+
+mail_home = /var/vmail/%d/%n
+mail_location = maildir:/var/vmail/%d/%n/:LAYOUT=fs
+
+# If you need to set multiple mailbox locations or want to change default
+# namespace settings, you can do it by defining namespace sections.
+namespace inbox {
+  inbox = yes
+
+  # See 15-mailboxes.conf for definitions of special mailboxes.
+}
+
+mail_uid = vmail
+mail_gid = vmail
+
+mail_privileged_group = vmail
+
+

--- a/etc/dovecot-conf-d/10-master.conf
+++ b/etc/dovecot-conf-d/10-master.conf
@@ -1,132 +1,55 @@
-#default_process_limit = 100
-#default_client_limit = 1000
-
-# Default VSZ (virtual memory size) limit for service processes. This is mainly
-# intended to catch and kill processes that leak memory before they eat up
-# everything.
-#default_vsz_limit = 256M
-
-# Login user is internally used by login processes. This is the most untrusted
-# user in Dovecot system. It shouldn't have access to anything at all.
-#default_login_user = dovenull
-
-# Internal user is used by unprivileged processes. It should be separate from
-# login user, so that login processes can't disturb other processes.
-#default_internal_user = dovecot
-
 service imap-login {
-  inet_listener imap {
-    #port = 143
-  }
   inet_listener imaps {
-    #port = 993
-    #ssl = yes
+    port = 993
+    ssl = yes
   }
-
-  # Number of connections to handle before starting a new process. Typically
-  # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
-  # is faster. <doc/wiki/LoginProcess.txt>
-  #service_count = 1
-
-  # Number of processes to always keep waiting for more connections.
-  #process_min_avail = 0
-
-  # If you set service_count=0, you probably need to grow this.
-  #vsz_limit = $default_vsz_limit
 }
 
 service pop3-login {
   inet_listener pop3 {
-    #port = 110
+    port = 110
   }
   inet_listener pop3s {
-    #port = 995
-    #ssl = yes
+    port = 995
+    ssl = yes
   }
 }
 
 service submission-login {
   inet_listener submission {
-    #port = 587
+    port = 587
   }
 }
 
 service lmtp {
-  unix_listener lmtp {
-    #mode = 0666
-  }
+    unix_listener /var/spool/postfix/private/dovecot-lmtp {
+        mode = 0660
+        group = postfix
+        user = postfix
+    }
 
-  # Create inet listener only if you can't use the above UNIX socket
-  #inet_listener lmtp {
-    # Avoid making LMTP visible for the entire internet
-    #address =
-    #port = 
-  #}
+    user = vmail
 }
 
-service imap {
-  # Most of the memory goes to mmap()ing files. You may need to increase this
-  # limit if you have huge mailboxes.
-  #vsz_limit = $default_vsz_limit
-
-  # Max. number of IMAP processes (connections)
-  #process_limit = 1024
+service managesieve-login {
+    inet_listener sieve {
+        port = 4190
+    }
 }
 
-service pop3 {
-  # Max. number of POP3 processes (connections)
-  #process_limit = 1024
-}
-
-service submission {
-  # Max. number of SMTP Submission processes (connections)
-  #process_limit = 1024
-}
 
 service auth {
-  # auth_socket_path points to this userdb socket by default. It's typically
-  # used by dovecot-lda, doveadm, possibly imap process, etc. Users that have
-  # full permissions to this socket are able to get a list of all usernames and
-  # get the results of everyone's userdb lookups.
-  #
-  # The default 0666 mode allows anyone to connect to the socket, but the
-  # userdb lookups will succeed only if the userdb returns an "uid" field that
-  # matches the caller process's UID. Also if caller's uid or gid matches the
-  # socket's uid or gid the lookup succeeds. Anything else causes a failure.
-  #
-  # To give the caller full permissions to lookup all users, set the mode to
-  # something else than 0666 and Dovecot lets the kernel enforce the
-  # permissions (e.g. 0777 allows everyone full permissions).
   unix_listener auth-userdb {
-    #mode = 0666
-    #user = 
-    #group = 
+    mode = 0660
+    user = vmail
+    group = vmail
   }
 
   # Postfix smtp-auth
   unix_listener /var/spool/postfix/private/auth {
-    mode = 0666
-	user = postfix
-	group = postfix
+    mode = 0660
+	  user = postfix
+	  group = postfix
   }
 
-  # Auth process is run as this user.
-  #user = $default_internal_user
-}
-
-service auth-worker {
-  # Auth worker process is run as root by default, so that it can access
-  # /etc/shadow. If this isn't necessary, the user should be changed to
-  # $default_internal_user.
-  #user = root
-}
-
-service dict {
-  # If dict proxy is used, mail processes should have access to its socket.
-  # For example: mode=0660, group=vmail and global mail_access_groups=vmail
-  unix_listener dict {
-    #mode = 0600
-    #user = 
-    #group = 
-  }
 }

--- a/etc/dovecot-conf-d/10-ssl.conf
+++ b/etc/dovecot-conf-d/10-ssl.conf
@@ -2,74 +2,8 @@
 ## SSL settings
 ##
 
-# SSL/TLS support: yes, no, required. <doc/wiki/SSL.txt>
-ssl = yes
+ssl = required 
 
-# PEM encoded X.509 SSL/TLS certificate and private key. They're opened before
-# dropping root privileges, so keep the key file unreadable by anyone but
-# root. Included doc/mkcert.sh can be used to easily generate self-signed
-# certificate, just make sure to update the domains in dovecot-openssl.cnf
 ssl_cert = <__PF_TLS_CERTCHAIN_FILE__
 ssl_key = <__PF_TLS_KEY_FILE__
 
-# If key file is password protected, give the password here. Alternatively
-# give it when starting dovecot with -p parameter. Since this file is often
-# world-readable, you may want to place this setting instead to a different
-# root owned 0600 file by using ssl_key_password = <path.
-#ssl_key_password =
-
-# PEM encoded trusted certificate authority. Set this only if you intend to use
-# ssl_verify_client_cert=yes. The file should contain the CA certificate(s)
-# followed by the matching CRL(s). (e.g. ssl_ca = </etc/ssl/certs/ca.pem)
-#ssl_ca = 
-
-# Require that CRL check succeeds for client certificates.
-#ssl_require_crl = yes
-
-# Directory and/or file for trusted SSL CA certificates. These are used only
-# when Dovecot needs to act as an SSL client (e.g. imapc backend or
-# submission service). The directory is usually /etc/ssl/certs in
-# Debian-based systems and the file is /etc/pki/tls/cert.pem in
-# RedHat-based systems.
-ssl_client_ca_dir = /etc/ssl/certs
-#ssl_client_ca_file =
-
-# Request client to send a certificate. If you also want to require it, set
-# auth_ssl_require_client_cert=yes in auth section.
-#ssl_verify_client_cert = no
-
-# Which field from certificate to use for username. commonName and
-# x500UniqueIdentifier are the usual choices. You'll also need to set
-# auth_ssl_username_from_cert=yes.
-#ssl_cert_username_field = commonName
-
-# SSL DH parameters
-# Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
-# Or migrate from old ssl-parameters.dat file with the command dovecot
-# gives on startup when ssl_dh is unset.
-ssl_dh = </usr/share/dovecot/dh.pem
-
-# Minimum SSL protocol version to use. Potentially recognized values are SSLv3,
-# TLSv1, TLSv1.1, and TLSv1.2, depending on the OpenSSL version used.
-#ssl_min_protocol = TLSv1
-
-# SSL ciphers to use, the default is:
-#ssl_cipher_list = ALL:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
-# To disable non-EC DH, use:
-#ssl_cipher_list = ALL:!DH:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
-
-# Colon separated list of elliptic curves to use. Empty value (the default)
-# means use the defaults from the SSL library. P-521:P-384:P-256 would be an
-# example of a valid value.
-#ssl_curve_list =
-
-# Prefer the server's order of ciphers over client's.
-#ssl_prefer_server_ciphers = no
-
-# SSL crypto device to use, for valid values run "openssl engine"
-#ssl_crypto_device =
-
-# SSL extra options. Currently supported options are:
-#   compression - Enable compression.
-#   no_ticket - Disable SSL session tickets.
-#ssl_options =

--- a/etc/dovecot-conf-d/15-mailboxes.conf
+++ b/etc/dovecot-conf-d/15-mailboxes.conf
@@ -1,0 +1,26 @@
+##
+## Mailbox definitions
+##
+
+# NOTE: Assumes "namespace inbox" has been defined in 10-mail.conf.
+namespace inbox {
+  inbox = yes
+
+  mailbox Drafts {
+    auto = subscribe
+    special_use = \Drafts
+  }
+  mailbox Spam {
+    auto = subscribe
+    special_use = \Junk
+  }
+  mailbox Trash {
+    auto = subscribe
+    special_use = \Trash
+  }
+
+  mailbox Sent {
+    auto = subscribe
+    special_use = \Sent
+  }
+}

--- a/etc/dovecot-conf-d/20-imap.conf
+++ b/etc/dovecot-conf-d/20-imap.conf
@@ -1,0 +1,9 @@
+##
+## IMAP specific settings
+##
+
+protocol imap {
+  mail_plugins = $mail_plugins quota imap_quota
+  mail_max_userip_connections = 20
+  imap_idle_notify_interval = 29 mins
+}

--- a/etc/dovecot-conf-d/20-lmtp.conf
+++ b/etc/dovecot-conf-d/20-lmtp.conf
@@ -2,26 +2,8 @@
 ## LMTP specific settings
 ##
 
-# Support proxying to other LMTP/SMTP servers by performing passdb lookups.
-#lmtp_proxy = no
-
-# When recipient address includes the detail (e.g. user+detail), try to save
-# the mail to the detail mailbox. See also recipient_delimiter and
-# lda_mailbox_autocreate settings.
-#lmtp_save_to_detail_mailbox = no
-
-# Verify quota before replying to RCPT TO. This adds a small overhead.
-#lmtp_rcpt_check_quota = no
-
-# Which recipient address to use for Delivered-To: header and Received:
-# header. The default is "final", which is the same as the one given to
-# RCPT TO command. "original" uses the address given in RCPT TO's ORCPT
-# parameter, "none" uses nothing. Note that "none" is currently always used
-# when a mail has multiple recipients.
-#lmtp_hdr_delivery_address = final
-
 protocol lmtp {
-  # Space separated list of plugins to load (default is global mail_plugins).
   mail_plugins = $mail_plugins sieve
+  postmaster_address = postmaster@__PF_MYDOMAIN__
 }
 

--- a/etc/dovecot-conf-d/90-sieve.conf
+++ b/etc/dovecot-conf-d/90-sieve.conf
@@ -1,0 +1,12 @@
+##
+## Settings for the Sieve interpreter
+##
+
+plugin {
+  sieve_before = /var/vmail/sieve/global/spam-global.sieve
+  sieve = /var/vmail/sieve/%d/%n/active-script.sieve
+  sieve_dir = /var/vmail/sieve/%d/%n/scripts
+
+  quota = maildir:User quota
+  quota_exceeded_message = User %u has exhausted allowed storage space.
+}

--- a/etc/dovecot/dovecot.conf
+++ b/etc/dovecot/dovecot.conf
@@ -1,165 +1,20 @@
-###
-### Aktivierte Protokolle
-#############################
+## Dovecot configuration file
 
-protocols = pop3 imap lmtp sieve
+# Enable installed protocols
+!include_try /usr/share/dovecot/protocols.d/*.protocol
 
+##
+## Dictionary server settings
+##
 
-
-###
-### TLS Config
-#######################
-ssl = required
-ssl_cert = <__PF_TLS_CERTCHAIN_FILE__
-ssl_key = <__PF_TLS_KEY_FILE__
-
-
-
-###
-### Dovecot services
-################################
-
-service imap-login {
-    inet_listener imap {
-        port = 143
-    }
-    inet_listener imaps {
-        port = 993
-		ssl = yes
-    }
+dict {
 }
 
-service pop3-login {
-    inet_listener pop3 {
-        port = 110
-    }
-}
+# Most of the actual configuration gets included below. The filenames are
+# first sorted by their ASCII value and parsed in that order. The 00-prefixes
+# in filenames are intended to make it easier to understand the ordering.
+!include conf.d/*.conf
 
-service managesieve-login {
-    inet_listener sieve {
-        port = 4190
-    }
-}
-
-
-service lmtp {
-    unix_listener /var/spool/postfix/private/dovecot-lmtp {
-        mode = 0660
-        group = postfix
-        user = postfix
-    }
-
-    user = vmail
-}
-
-
-service auth {
-    ### Auth socket für Postfix
-    unix_listener /var/spool/postfix/private/auth {
-        mode = 0660
-        user = postfix
-        group = postfix
-    }
-
-    ### Auth socket für LMTP-Dienst
-    unix_listener auth-userdb {
-        mode = 0660
-        user = vmail
-        group = vmail
-    }
-}
-
-
-###
-###  Protocol settings
-#############################
-
-protocol imap {
-    mail_plugins = $mail_plugins quota imap_quota 
-    mail_max_userip_connections = 20
-    imap_idle_notify_interval = 29 mins
-}
-
-protocol lmtp {
-    postmaster_address = postmaster@__PF_MYDOMAIN__
-    mail_plugins = $mail_plugins sieve
-}
-
-
-
-###
-### Client authentication
-#############################
-
-disable_plaintext_auth = yes
-auth_mechanisms = plain login
-
-passdb {
-    driver = sql
-    args = /etc/dovecot/dovecot-sql.conf
-}
-
-userdb {
-    driver = sql
-    args = /etc/dovecot/dovecot-sql.conf
-}
-
-
-###
-### Mail location
-#######################
-
-mail_uid = vmail
-mail_gid = vmail
-mail_privileged_group = vmail
-
-
-mail_home = /var/vmail/%d/%n
-mail_location = maildir:/var/vmail/%d/%n/:LAYOUT=fs
-
-
-
-###
-### Mailbox configuration
-########################################
-
-namespace inbox {
-    inbox = yes
-
-    mailbox Spam {
-        auto = subscribe
-        special_use = \Junk
-    }
-
-    mailbox Trash {
-        auto = subscribe
-        special_use = \Trash
-    }
-
-    mailbox Drafts {
-        auto = subscribe
-        special_use = \Drafts
-    }
-
-    mailbox Sent {
-        auto = subscribe
-        special_use = \Sent
-    }
-}
-
-
-
-###
-### Mail plugins
-############################
-
-
-plugin {
-    sieve_before = /var/vmail/sieve/global/spam-global.sieve   
-    sieve = /var/vmail/sieve/%d/%n/active-script.sieve
-    sieve_dir = /var/vmail/sieve/%d/%n/scripts
-
-    quota = maildir:User quota
-    quota_exceeded_message = User %u has exhausted allowed storage space.
-
-}
+# A config file can also tried to be included without giving an error if
+# it's not found:
+!include_try local.conf


### PR DESCRIPTION
This is a fix for issue #31 

The resulting configuration is line-for-line identical to the original configuration, but now spread over multiple files, making extending and editing the config much easier.

I did remove the majority of comments, they can still be found in the .bak files once the server is running. 