### PR TITLE
feat(postfix): add support for extending mynetworks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ _mailserver-postfix_  requires various environment variables to be set. The cont
 | `PF_TLS_CAPATH` | Directory that contains trusted CA root certificates. | `/etc/ssl/certs` |
 | `PF_TLS_CAFILE` | Name of single file that contains trusted CA root certificates. | `/etc/postfix/CAcert.pem` |
 | `PF_TLS_ADMIN_EMAIL` | E-mail address to be notified when TLS certificate is about to expire (10 days) | `postmaster@$PF_MYDOMAIN` |
+| `PF_ADD_MYNETWORKS`| A string containing additional subnets with a mask to add to the `mynetworks` file in main.cf  |  |
 
 ## Volumes
 You need to provide data volumes in order to secure your mailboxes from data loss. 

--- a/etc/postfix/main.cf
+++ b/etc/postfix/main.cf
@@ -1,7 +1,7 @@
 ##
 ## NETWORKING
 ##
-mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 __PF_ADD_MYNETWORKS__
 inet_interfaces = all
 myhostname = __PF_MYHOSTNAME__
 myorigin = __PF_MYORIGIN__

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -74,6 +74,9 @@ fi
 if [[ -z "${PF_MILTERS}" ]]; then
 	PF_MILTERS=
 fi
+if [[ -z "${PF_ADD_MYNETWORKS}" ]]; then
+	PF_ADD_MYNETWORKS=
+fi
 ####################
 # Helper functions
 ####################
@@ -131,6 +134,7 @@ copy_template_file() {
 		replace_var $TMP_DST 'PF_DB_PASS'
 		replace_var $TMP_DST 'PF_ENABLE_UTF8'
 		replace_var $TMP_DST 'PF_MILTERS'
+		replace_var $TMP_DST 'PF_ADD_MYNETWORKS'
 	fi
 	if [ ! -f $TMP_DST ]; then
 		echo "Cannot create $TMP_DST" 1>&2


### PR DESCRIPTION
Allows users to specify extra network addresses for postfix mynetworks configuration by setting the PF_ADD_MYNETWORKS environment variable.